### PR TITLE
StringTable Bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kerbalobjects"
-version = "3.1.10"
+version = "3.1.11"
 authors = ["Luke Newcomb <newcomb.luke@protonmail.com>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/src/kofile/sections.rs
+++ b/src/kofile/sections.rs
@@ -8,7 +8,6 @@ use crate::{FromBytes, KOSValue, ToBytes};
 use crate::errors::{ReadError, ReadResult};
 
 use super::{instructions::Instr, symbols::KOSymbol, symbols::ReldEntry, SectionFromBytes};
-use std::mem;
 
 pub trait SectionIndex {
     fn section_index(&self) -> usize;
@@ -170,7 +169,7 @@ impl SectionIndex for SymbolTable {
 impl SymbolTable {
     pub fn new(amount: usize, section_index: usize) -> Self {
         SymbolTable {
-            symbols: Vec::with_capacity(amount * mem::size_of::<KOSymbol>()),
+            symbols: Vec::with_capacity(amount),
             size: 0,
             section_index,
         }
@@ -256,8 +255,15 @@ impl SectionIndex for StringTable {
 
 impl StringTable {
     pub fn new(amount: usize, section_index: usize) -> Self {
+        let empty = String::new();
+        let mut hasher = DefaultHasher::new();
+        hasher.write(empty.as_bytes());
+        let hash = hasher.finish();
+
         let mut contents = Vec::with_capacity(amount);
-        contents.push(String::new());
+        contents.push(empty);
+        let mut hashes = Vec::with_capacity(amount);
+        hashes.push(hash);
 
         StringTable {
             hashes: Vec::new(),


### PR DESCRIPTION
The string indices returned by str_tab.find() were off by 1. 